### PR TITLE
Initial Websocket Implementation for Code Execution in Assessments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ source venv/bin/activate
 pip install -U pip
 pip install -r requirements.txt
 python manage.py migrate
-python manage.py runserver
+daphne compeng_gg.asgi:application
 ```
 
 Running
@@ -37,7 +37,7 @@ Running
 ```
 cd backend
 source venv/bin/activate
-python manage.py runserver
+daphne compeng_gg.asgi:application
 ```
 
 Run Unit Tests

--- a/backend/api/v0/websocket_urls.py
+++ b/backend/api/v0/websocket_urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+import courses.assessments.api.websockets as assessments_websocket_api
+
+websocket_urlpatterns = [
+    path('api/ws/v0/assessments/<uuid:assessment_id>/run_code/<uuid:coding_question_id>/', assessments_websocket_api.CodeRunConsumer.as_asgi()),
+]

--- a/backend/compeng_gg/asgi.py
+++ b/backend/compeng_gg/asgi.py
@@ -13,4 +13,53 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'compeng_gg.settings')
 
-application = get_asgi_application()
+asgi_application = get_asgi_application()
+
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.db import database_sync_to_async
+from rest_framework_simplejwt.tokens import UntypedToken
+from api.v0.websocket_urls import websocket_urlpatterns
+from django.contrib.auth.models import (
+    AnonymousUser,
+    User
+)
+
+
+@database_sync_to_async
+def get_user_from_token(token):
+    try:
+        valid_data = UntypedToken(token)
+        return User.objects.get(id=valid_data['user_id'])
+    except Exception:
+        return AnonymousUser()
+
+
+class TokenAuthMiddleware:
+    """
+    Custom middleware for WebSocket token authentication.
+    """
+    def __init__(self, inner):
+        self.inner = inner
+
+    async def __call__(self, scope, receive, send):
+        query_string = scope.get('query_string', b'').decode()
+        params = dict(pair.split('=') for pair in query_string.split('&') if '=' in pair)
+
+        token = params.get('token')
+
+        if token is None:
+            raise Exception()
+
+        scope['user'] = await get_user_from_token(token)
+ 
+        return await self.inner(scope, receive, send)
+
+
+application = ProtocolTypeRouter({
+    'http': asgi_application,
+    'websocket': TokenAuthMiddleware(
+        URLRouter(
+            websocket_urlpatterns,  # Add the prefix here
+        )
+    ),
+})

--- a/backend/courses/assessments/api/websockets/__init__.py
+++ b/backend/courses/assessments/api/websockets/__init__.py
@@ -1,0 +1,1 @@
+from courses.assessments.api.websockets.code_run_consumer import CodeRunConsumer

--- a/backend/courses/assessments/api/websockets/code_run_consumer.py
+++ b/backend/courses/assessments/api/websockets/code_run_consumer.py
@@ -1,0 +1,27 @@
+import json
+from channels.generic.websocket import AsyncWebsocketConsumer
+import time
+
+class CodeRunConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        kwargs = self.scope['url_route']['kwargs']
+
+        self.assessment_id = kwargs.get('assessment_id')
+        self.coding_question_id = kwargs.get('coding_question_id')
+        
+        await self.accept()
+
+    async def receive(self, text_data):
+        data = json.loads(text_data)
+        solution = data['solution']
+
+        # TODO: actually run code
+
+        time.sleep(5)
+
+        response_data = {
+            'test_cases_passed': 2,
+            'test_cases_failed': 5
+        }
+
+        await self.send(text_data=json.dumps(response_data))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -30,3 +30,5 @@ urllib3==2.2.2
 yarl==1.9.4
 pytest==8.3.3
 pytest-django==4.9.0
+pytest-asyncio==0.24.0
+channels[daphne]==4.2.0

--- a/backend/tests/courses/assessments/websockets/test_code_run_consumer.py
+++ b/backend/tests/courses/assessments/websockets/test_code_run_consumer.py
@@ -1,0 +1,46 @@
+import pytest
+from channels.testing import WebsocketCommunicator
+from courses.assessments.api.websockets import CodeRunConsumer
+from channels.routing import URLRouter
+from django.urls import path
+
+
+@pytest.mark.asyncio
+async def test_code_run_consumer_happy_path():
+    # Define test parameters
+    test_assessment_id = '123e4567-e89b-12d3-a456-426614174000'
+    test_coding_question_id = '987e6543-e21b-45c6-b123-426614174000'
+
+    # Define WebSocket application for testing
+    application = URLRouter([
+        path('api/v0/ws/assessments/<uuid:assessment_id>/run_code/<uuid:coding_question_id>/', CodeRunConsumer.as_asgi()),
+    ])
+
+    # Define the WebSocket URL with the parameters
+    url = f'api/v0/ws/assessments/{test_assessment_id}/run_code/{test_coding_question_id}/'
+
+    # Create a WebSocket communicator for testing
+    communicator = WebsocketCommunicator(application, url)
+
+    try:
+        # Connect to the WebSocket
+        connected, _ = await communicator.connect()
+        assert connected
+
+        # Send a test message
+        solution = "print('Hello World!')"
+
+        test_message = {
+            'solution': solution
+        }
+        await communicator.send_json_to(test_message)
+
+        # Receive the response
+        response = await communicator.receive_json_from()
+        
+        assert response['test_cases_passed'] == 2
+        assert response['test_cases_failed'] == 5
+
+    finally:
+        # Ensure the WebSocket is closed to avoid dangling tasks
+        await communicator.disconnect()


### PR DESCRIPTION
NOTE: you need to run the local server with: `daphne compeng_gg.asgi:application` now, as Django doesn't support websockets natively

Hit the web socket endpoint:

`api/ws/v0/assessments/<uuid:assessment_id>/run_code/<uuid:coding_question_id>/?token=the_user_jwt` to establish a connection

Currently, this accepts ANY valid UUID params.

Then, send JSON encoded data:
```
{
   "solution": str
}
```

The websocket handler is currently hardcoded to `sleep` for 5 seconds, then responds with the JSON data:
```
{
   "tests_passed": int,
   "tests_failed": int
}
```

You can run this Python script to verify it's working (when server is running)

```
import asyncio
import websockets
import json
from uuid import uuid4

async def connect_to_websocket():
    uri = f"ws://127.0.0.1:8000/api/ws/v0/assessments/{str(uuid4())}/run_code/{str(uuid4())}/?token=the_url_encoded_token"  # Replace with your WebSocket URL
    try:
        async with websockets.connect(uri) as websocket:
            print("Connected to WebSocket server.")

            # Send a message to the server
            message = {"solution": "Hello, Django WebSocket!"}
            await websocket.send(json.dumps(message))
            print(f"Sent: {message}")

            # Wait for a response
            response = await websocket.recv()
            print(f"Received: {json.loads(response)}")

    except Exception as e:
        print(f"Error: {e}")
        print()
 

# Run the asyncio event loop
asyncio.run(connect_to_websocket())
```